### PR TITLE
Create msg-files for the first run.

### DIFF
--- a/ml-stat.py
+++ b/ml-stat.py
@@ -168,6 +168,9 @@ def prep_files(file_dir, git_dir, n):
     # os.listdir
     # os.path import isfile, join
 
+    if not os.path.isdir(file_dir):
+        os.mkdir(file_dir)
+
     files = set()
     for f in os.listdir(file_dir):
         if not os.path.isfile(os.path.join(file_dir, f)):


### PR DESCRIPTION
Otherwise, we will see this error.

Traceback (most recent call last):
  File "/mnt/ec2-user/kernel/tools/ml-stat/./ml-stat.py", line 408, in <module>
    main()
  File "/mnt/ec2-user/kernel/tools/ml-stat/./ml-stat.py", line 290, in main
    prep_files('msg-files', 'netdev-2.git', args.email_count)
  File "/mnt/ec2-user/kernel/tools/ml-stat/./ml-stat.py", line 172, in prep_files
    for f in os.listdir(file_dir):
FileNotFoundError: [Errno 2] No such file or directory: 'msg-files'

Signed-off-by: Kuniyuki Iwashima <kuniyu@amazon.com>