### PR TITLE
ml-stat: heuristics order for names with comma

### DIFF
--- a/ml-stat.py
+++ b/ml-stat.py
@@ -480,6 +480,21 @@ def name_check_sort_heuristics(idents):
             print(f"INFO: target identity set as a subset!")
             return
 
+    # One with comma, one without
+    if len(idents) == 2:
+        comma1st = ',' in idents[0]
+        comma2nd = ',' in idents[1]
+        if comma1st != comma2nd:
+            # Doe, John vs Doe John (comma is better, looks naively removed)
+            # Doe, John vs John Doe (comma-less is better)
+            # (does not matter if one is Jonathan)
+            if idents[0].split()[0].rstrip(',') == idents[1].split()[0].rstrip(','):
+                if comma1st:
+                    idents.reverse()
+            elif comma2nd:
+                    idents.reverse()
+            return
+
     # Sort anything that contains " first
     idents.sort(key=lambda v: -v.find('"'))
 


### PR DESCRIPTION
Fix order of names with comma, as it is typical for corporate names to be send as "Surname, FirstName" while the prefered style is "FirstName Surname". Some people get if wrong and just remove the comma, in such cases it's better to have the one with comma kept.

I have checked all emails with multiple identities for 6.12...6.13 and it looks to work great for the mentioned cases, even for cases with more than two names.