### PR TITLE
ml-stat: stop marking person replying to PR as an author

### DIFF
--- a/ml-stat.py
+++ b/ml-stat.py
@@ -78,10 +78,15 @@ class EmailPost:
                 return True
         return False
 
+    def is_reply(self):
+        return self._subject[:4].lower() == 're: '
+
     def is_patch(self):
         return self._subject[0] == '[' and not self.is_pr() and not self._is_discussion()
 
     def is_pr(self):
+        if self.is_reply():
+            return False
         return 'pull req' in self._subject or 'pull-req' in self._subject
 
     def is_bugzilla_forward(self):
@@ -114,8 +119,7 @@ class EmailMsg(EmailPost):
         if self._body_processed is not None:
             return
         self._body_processed = True
-        # TODO: also match RE?
-        if not self.subject().startswith('Re: '):
+        if not self.is_reply():
             return
 
         body = self.msg.get_body(preferencelist=('plain',))

--- a/ml-stat.py
+++ b/ml-stat.py
@@ -82,7 +82,6 @@ class EmailPost:
         return self._subject[0] == '[' and not self.is_pr() and not self._is_discussion()
 
     def is_pr(self):
-        return 'pull req' in self._subject
         return 'pull req' in self._subject or 'pull-req' in self._subject
 
     def is_bugzilla_forward(self):


### PR DESCRIPTION
When someone replyies to PR, it should be treated as participant/reviewer instead of being an author.

The impact for stats is minor, as there is not much PRs comparted to all threads. It touches mostly Maintainers, giving them less "authorship" in exchange for more positive score.

It also stops assigining high "outgoing PRs" number to Jakub or Paolo for merely commenting on vendor' PRs; let alone assigning any such score to Linus.